### PR TITLE
:truck: Change conteneurs names by removing app name prefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ export NPM_REGISTRY = $(shell echo $$NPM_REGISTRY )
 export NPM_VERBOSE = 1
 
 # KIBANA
-export KIBANA_HOST = ${APP}-kibana
+export KIBANA_HOST = kibana
 export KIBANA_PORT = 5601
 
 # LOGSTASH
@@ -38,7 +38,7 @@ export LOGSTASH_HOST = ${APP}-logstash
 # BACKEND dir
 export BACKEND=${APP_PATH}/backend
 export BACKEND_PORT=5000
-export BACKEND_HOST = ${APP}-backend
+export BACKEND_HOST = backend
 
 # frontend dir
 export FRONTEND_PORT=3000

--- a/docker-compose-frontend-build.yml
+++ b/docker-compose-frontend-build.yml
@@ -10,7 +10,7 @@ services:
         https_proxy: ${https_proxy}
         no_proxy: ${no_proxy}
     image: ${APP}-frontend-build:${APP_VERSION}
-    container_name: ${APP}-frontend-build
+    container_name: frontend-build
     environment:
       - http_proxy
       - https_proxy

--- a/docker-compose-logstash.yml
+++ b/docker-compose-logstash.yml
@@ -3,7 +3,7 @@ version: '2'
 services:
   logstash:
     #image: docker.elastic.co/elasticsearch/elasticsearch-oss:${ES_VERSION}
-    container_name: ${DC_PREFIX}-logstash
+    container_name: logstash
     image: docker.elastic.co/logstash/logstash-oss:${ES_VERSION}
     environment:
       PATH_CONFIG: "/usr/share/logstash/pipeline" # default

--- a/docker-compose-nginx-dev.yml
+++ b/docker-compose-nginx-dev.yml
@@ -1,8 +1,8 @@
 version: '3.4'
 services:
   nginx-dev:
-    image: ${APP}-nginx-dev
-    container_name: ${APP}-nginx-dev
+    image: nginx-dev
+    container_name: nginx-dev
     build:
       context: ${NGINX}
       target: development

--- a/docker-compose-nginx.yml
+++ b/docker-compose-nginx.yml
@@ -1,7 +1,7 @@
 version: '3.4'
 services:
   nginx-production:
-    image: ${APP}-nginx-production:${APP_VERSION}
+    image: nginx-production:${APP_VERSION}
     build:
       context: ${NGINX}
       target: production
@@ -11,7 +11,7 @@ services:
         app_ver: ${APP_VERSION}
 
 
-    container_name: ${DC_PREFIX}-nginx-production
+    container_name: nginx-production
 
     environment:
       - APP

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - ${ENV_FILE}
   tika:
     image: logicalspark/docker-tikaserver
-    container_name: ${DC_PREFIX}-tika
+    container_name: tika
     expose:
       - "9998"
     ports:


### PR DESCRIPTION
Simplification de nommage des coneteneurs.
browser-frontend -> frontend par ex.

A faire une fois: 
- Ajouter dans artifacts **export DC_UP_ARGS=--build --force-recreate** afin de recréer les images au cas ou
- **Il faudra si besoin supprimer les anciens conteneneurs avec docker rm id -f** 
