### PR TITLE
Origin/feat/accordion with svelte transition bis

### DIFF
--- a/frontend/src/common/accordion/AccordionItem.svelte
+++ b/frontend/src/common/accordion/AccordionItem.svelte
@@ -1,7 +1,8 @@
 <script>
-	import { createEventDispatcher, getContext } from 'svelte';
+	import { createEventDispatcher,getContext } from 'svelte';
+	import { sineInOut } from 'svelte/easing';
 	import { writable } from 'svelte/store';
-	import { cssProps } from '../css-props.action';
+	import { slide } from 'svelte/transition';
 	import { contextKey } from './accordion';
 
 	/** store pour la valeur de sélection */
@@ -28,6 +29,9 @@
 	/** styles CSS du contenu */
 	export let contentStyle = undefined;
 
+	/** paramètres de transition */
+	export let slideParams = {};
+
 	/**
 	 * texte pour le titre
 	 * alternative : passer un slot 'title'
@@ -41,24 +45,18 @@
 	export let content = 'contenu';
 	
 	const dispatch = createEventDispatcher();
-	const bgHeightProp = 'max-height';
-	const styleProps = {};
 	
 	/** élément DOM externe (élément de liste) */
 	let itemNode;
 	
-	/** élément DOM correspondant au contenu */
-	let contentNode;
+	let derivedSlideParams;
+	$: derivedSlideParams = { duration: 700, easing: sineInOut, ...slideParams };
 	
 	let expanded;
 	
 	$: {
 		const oldValue = expanded;
 		expanded = $selection === itemValue;
-		styleProps[bgHeightProp] =
-			contentNode && expanded
-				? contentNode.scrollHeight + 'px'
-				: undefined;
 		if (oldValue != expanded) {
 			dispatch('expand', { itemNode, expanded });
 		}
@@ -83,20 +81,18 @@
 			</div>
 		</slot>
 	</button>
-
-	<div bind:this={contentNode} use:cssProps={styleProps} class="relative overflow-hidden max-h-0 {contentClass || ''}" style={contentStyle}>
-		<slot name="content">
-			<div class="p-6">
-				<p>{content}</p>
-			</div>
-		</slot>
-	</div>
+	{#if expanded}
+		<div transition:slide|local={derivedSlideParams} class={contentClass} style={contentStyle}>
+			<slot name="content">
+				<div class="p-6">
+					<p>{content}</p>
+				</div>
+			</slot>
+		</div>
+	{/if}
 </li>
 
 <style>
-	.max-h-0 {
-		max-height: 0;
-	}
 	button {
 		@apply w-full;
 		@apply px-2;
@@ -104,10 +100,6 @@
 		/* @apply border-b; */
 		@apply outline-none;
 		@apply text-left;
-	}
-	button + div {
-		@apply transition-all;
-		@apply duration-700;
 	}
 	/** ignore this warning (unused) */
 	/*

--- a/frontend/src/routes/tests.svelte
+++ b/frontend/src/routes/tests.svelte
@@ -3,6 +3,7 @@
 </svelte:head>
 
 <script>
+	import { elasticInOut, expoInOut } from 'svelte/easing';
 	import { writable } from 'svelte/store';
 	import Accordion from '../common/accordion/Accordion.svelte';
 	import AccordionItem from '../common/accordion/AccordionItem.svelte';
@@ -72,6 +73,15 @@
 				<p>ouvert au départ</p>
 				<ul>
 					<AccordionItem selection={writable('peuImporte')} itemValue={'peuImporte'} />
+				</ul>
+			</div>
+
+			<div>
+				<p>avec transition personnalisée</p>
+				<ul>
+					<AccordionItem title="easing" itemValue={1} contentStyle="height: 100px" slideParams={{ easing: elasticInOut }} />
+					<AccordionItem title="durée" itemValue={2} contentStyle="height: 200px" slideParams={{ duration: 5000 }} />
+					<AccordionItem title="durée + easing" itemValue={3} contentStyle="height: 300px" slideParams={{ duration: 3000, easing: expoInOut }} />
 				</ul>
 			</div>
 


### PR DESCRIPTION
une alternative à la PR https://github.com/datalab-mi/moteur-de-recherche/pull/97 car il me semble que les transitions de base suffisent (j'ai pris "slide") et avec les transitions le CSS devient inutile

les paramètres de transition (toujours slide) peuvent être spécifiés par le parent, et j'ai ajouté un test